### PR TITLE
Casacade and Task fields datatype change

### DIFF
--- a/sql-code/db-setup.sql
+++ b/sql-code/db-setup.sql
@@ -13,19 +13,19 @@ CREATE TABLE `User` (
 
 CREATE TABLE Workspace (
     ID varchar(64) NOT NULL PRIMARY KEY,
-    CreatedAt bigint NOT NULL,
+    CreatedAt DateTime(6) NOT NULL,
     CreatedBy varchar(64) NOT NULL,
-    LastUpdated bigint NOT NULL,
+    LastUpdated DateTime(6) NOT NULL,
     UpdatedBy varchar(64) NOT NULL,
-    FOREIGN KEY (CreatedBy) REFERENCES User(ID),
-    FOREIGN KEY (UpdatedBy) REFERENCES User(ID)
+    FOREIGN KEY (CreatedBy) REFERENCES User(ID) ON DELETE CASCADE ON UPDATE CASCADE,
+    FOREIGN KEY (UpdatedBy) REFERENCES User(ID) ON DELETE CASCADE ON UPDATE CASCADE
 ) ENGINE=INNODB;
 
 CREATE TABLE UserWorkspaceRelation (
     UserID varchar(64) NOT NULL, 
     WorkspaceID varchar(64) NOT NULL,
-    FOREIGN KEY (UserID) REFERENCES `User`(ID),
-    FOREIGN KEY (WorkspaceID) REFERENCES Workspace(ID)
+    FOREIGN KEY (UserID) REFERENCES `User`(ID) ON DELETE CASCADE ON UPDATE CASCADE,
+    FOREIGN KEY (WorkspaceID) REFERENCES Workspace(ID) ON DELETE CASCADE ON UPDATE CASCADE
 ) ENGINE=INNODB;
 
 CREATE TABLE WorkspaceUser (
@@ -34,25 +34,25 @@ CREATE TABLE WorkspaceUser (
     `Role` smallint NOT NULL,
     WorkspaceID varchar(64) NOT NULL,
     DepartmentID varchar(64),
-    FOREIGN KEY (UserID) REFERENCES `User`(ID),
-    FOREIGN KEY (WorkspaceID) REFERENCES Workspace(ID)
+    FOREIGN KEY (UserID) REFERENCES `User`(ID) ON DELETE CASCADE ON UPDATE CASCADE,
+    FOREIGN KEY (WorkspaceID) REFERENCES Workspace(ID) ON DELETE CASCADE ON UPDATE CASCADE 
 ) ENGINE=INNODB;
 
 CREATE TABLE Department (
     ID varchar(64) NOT NULL PRIMARY KEY,
     WorkspaceID varchar(64) NOT NULL,
-    CreatedAt bigint NOT NULL,
+    CreatedAt DateTime(6) NOT NULL,
     CreatedBy varchar(64) NOT NULL,
-    LastUpdated bigint NOT NULL,
+    LastUpdated DateTime(6) NOT NULL,
     UpdatedBy varchar(64) NOT NULL,
     Title varchar(128) NOT NULL,
     `Description` varchar(512),
-    FOREIGN KEY (WorkspaceID) REFERENCES Workspace(ID),
-    FOREIGN KEY (CreatedBy) REFERENCES WorkspaceUser(ID),
-    FOREIGN KEY (UpdatedBy) REFERENCES WorkspaceUser(ID)
+    FOREIGN KEY (WorkspaceID) REFERENCES Workspace(ID) ON DELETE CASCADE ON UPDATE CASCADE,
+    FOREIGN KEY (CreatedBy) REFERENCES WorkspaceUser(ID) ON DELETE CASCADE ON UPDATE CASCADE,
+    FOREIGN KEY (UpdatedBy) REFERENCES WorkspaceUser(ID) ON DELETE CASCADE ON UPDATE CASCADE
 ) ENGINE=INNODB;
 
-ALTER TABLE WorkspaceUser ADD FOREIGN KEY (DepartmentID) REFERENCES Department(ID); 
+ALTER TABLE WorkspaceUser ADD FOREIGN KEY (DepartmentID) REFERENCES Department(ID) ON DELETE CASCADE; 
 
 /*Added TotalCost and TotalEffort fields to keep track of real cost and effort computed by a summation
 	of the project's tasks' CostActual and EffortActual fields.
@@ -62,26 +62,26 @@ CREATE TABLE Project (
     ID varchar(64) NOT NULL PRIMARY KEY,
     WorkspaceID varchar(64) NOT NULL,
     DepartmentID varchar(64),
-    CreatedAt bigint NOT NULL,
+    CreatedAt DateTime(6) NOT NULL,
     CreatedBy varchar(64) NOT NULL,
-    LastUpdated bigint NOT NULL,
+    LastUpdated DateTime(6) NOT NULL,
     UpdatedBy varchar(64) NOT NULL,
     Title varchar(128) NOT NULL,
     EstimatedCost float,
     EstimatedEffort float,
     ActualCost float DEFAULT 0,
     ActualEffort float DEFAULT 0,
-    FOREIGN KEY (WorkspaceID) REFERENCES Workspace(ID),
-    FOREIGN KEY (DepartmentID) REFERENCES Department(ID),
-    FOREIGN KEY (CreatedBy) REFERENCES WorkspaceUser(ID),
-    FOREIGN KEY (UpdatedBy) REFERENCES WorkspaceUser(ID)
+    FOREIGN KEY (WorkspaceID) REFERENCES Workspace(ID) ON DELETE CASCADE ON UPDATE CASCADE,
+    FOREIGN KEY (DepartmentID) REFERENCES Department(ID) ON DELETE CASCADE ON UPDATE CASCADE,
+    FOREIGN KEY (CreatedBy) REFERENCES WorkspaceUser(ID) ON DELETE CASCADE ON UPDATE CASCADE,
+    FOREIGN KEY (UpdatedBy) REFERENCES WorkspaceUser(ID) ON DELETE CASCADE ON UPDATE CASCADE
 ) ENGINE=INNODB;
 
 CREATE TABLE WorkspaceUserProjectRelation (
     WorkspaceUserID varchar(64) NOT NULL,
     ProjectID varchar(64) NOT NULL,
-    FOREIGN KEY (WorkspaceUserID) REFERENCES WorkspaceUser(ID),
-    FOREIGN KEY (ProjectID) REFERENCES Project(ID)
+    FOREIGN KEY (WorkspaceUserID) REFERENCES WorkspaceUser(ID) ON DELETE CASCADE ON UPDATE CASCADE,
+    FOREIGN KEY (ProjectID) REFERENCES Project(ID) ON DELETE CASCADE ON UPDATE CASCADE
 ) ENGINE=INNODB;
 
 CREATE TABLE Task (
@@ -89,9 +89,9 @@ CREATE TABLE Task (
     ProjectID varchar(64) NOT NULL,
     WorkspaceID varchar(64) NOT NULL,
     ParentTaskID varchar(64),
-    CreatedAt bigint NOT NULL,
+    CreatedAt DateTime(6) NOT NULL,
     CreatedBy varchar(64) NOT NULL,
-    LastUpdated bigint NOT NULL,
+    LastUpdated DateTime(6) NOT NULL,
     UpdatedBy varchar(64) NOT NULL,
     Title varchar(128) NOT NULL,
     `Description` varchar(512),
@@ -100,15 +100,15 @@ CREATE TABLE Task (
     EstimatedEffort float,
     ActualCost float DEFAULT 0,
     ActualEffort float DEFAULT 0,
-    StartDate bigint,
-    DueDate bigint,
-    TaskStarted bigint,
-    TaskEnded bigint,
-    FOREIGN KEY (ProjectID) REFERENCES Project(ID),
-    FOREIGN KEY (WorkspaceID) REFERENCES Workspace(ID),
-    FOREIGN KEY (ParentTaskID) REFERENCES Task(ID),
-    FOREIGN KEY (CreatedBy) REFERENCES WorkspaceUser(ID),
-    FOREIGN KEY (UpdatedBy) REFERENCES WorkspaceUser(ID)
+    StartDate DateTime(6),
+    DueDate DateTime(6),
+    TaskStarted DateTime(6),
+    TaskEnded DateTime(6),
+    FOREIGN KEY (ProjectID) REFERENCES Project(ID) ON DELETE CASCADE ON UPDATE CASCADE,
+    FOREIGN KEY (WorkspaceID) REFERENCES Workspace(ID) ON DELETE CASCADE ON UPDATE CASCADE,
+    FOREIGN KEY (ParentTaskID) REFERENCES Task(ID) ON DELETE CASCADE ON UPDATE CASCADE,
+    FOREIGN KEY (CreatedBy) REFERENCES WorkspaceUser(ID) ON DELETE CASCADE ON UPDATE CASCADE,
+    FOREIGN KEY (UpdatedBy) REFERENCES WorkspaceUser(ID)ON DELETE CASCADE ON UPDATE CASCADE 
 ) ENGINE=INNODB;
 
 CREATE TABLE Tag (
@@ -117,9 +117,9 @@ CREATE TABLE Tag (
     ProjectID varchar(64) NOT NULL,
     TaskID varchar(64),
     Message varchar(256),
-    FOREIGN KEY (TaskID) REFERENCES Task(ID),
-    FOREIGN KEY (ProjectID) REFERENCES Project(ID),
-    FOREIGN KEY (WorkspaceID) REFERENCES Workspace(ID)
+    FOREIGN KEY (TaskID) REFERENCES Task(ID) ON DELETE CASCADE ON UPDATE CASCADE,
+    FOREIGN KEY (ProjectID) REFERENCES Project(ID) ON DELETE CASCADE ON UPDATE CASCADE,
+    FOREIGN KEY (WorkspaceID) REFERENCES Workspace(ID) ON DELETE CASCADE ON UPDATE CASCADE
 ) ENGINE=INNODB;
 
 /*Triggers*/


### PR DESCRIPTION
-- All deletions and updates to parent table now cascade to all relations.
--Task table StartDate, DueDate, TaskStarted, and TaskEnded fields changed to Datetime(6) datatype from bigint.